### PR TITLE
Deprecated instances of np.int were replaced with np.int32

### DIFF
--- a/utime/models/utime.py
+++ b/utime/models/utime.py
@@ -364,7 +364,7 @@ class UTime(Model):
 
         if np.any(s1 != s2):
             self.n_crops += 1
-            c = (s1 - s2).astype(np.int)
+            c = (s1 - s2).astype(np.int32)
             cr = np.array([c // 2, c // 2]).flatten()
             cr[self.n_crops % 2] += c % 2
             cropped_node1 = Cropping2D([list(cr), [0, 0]])(node1)

--- a/utime/sequences/base_sequence.py
+++ b/utime/sequences/base_sequence.py
@@ -201,7 +201,7 @@ class BaseSequence(_BaseSequence):
             An ndarray of class counts across all stored SleepStudy objects
             Shape [self.n_classes], dtype np.int
         """
-        counts = np.zeros(shape=[self.n_classes], dtype=np.int)
+        counts = np.zeros(shape=[self.n_classes], dtype=np.int32)
         for im in self.dataset_queue:
             count_dict = im.get_class_counts(as_dict=True)
             for cls, count in count_dict.items():

--- a/utime/sequences/multi_sequence.py
+++ b/utime/sequences/multi_sequence.py
@@ -115,7 +115,7 @@ class MultiSequence(_BaseSequence):
 
     def get_class_counts(self):
         """ Returns the sum of class counts over all sequences """
-        counts = np.zeros(shape=[self.sequences[0].n_classes], dtype=np.int)
+        counts = np.zeros(shape=[self.sequences[0].n_classes], dtype=np.int32)
         for seq in self.sequences:
             counts += seq.get_class_counts()
         return counts

--- a/utime/utils/conv_arithmetics.py
+++ b/utime/utils/conv_arithmetics.py
@@ -24,7 +24,7 @@ def output_features(in_filter_size, padding, kernel_size, stride=1, dim=2):
                                                                   stride],
                                                                  dim=dim)
 
-    return np.floor((in_filter_size + (2*padding) - kernel_size)/stride).astype(np.int) + 1
+    return np.floor((in_filter_size + (2*padding) - kernel_size)/stride).astype(np.int32) + 1
 
 
 def output_feature_distance(input_feature_distance, stride, dim=2):
@@ -82,9 +82,9 @@ def compute_receptive_fields(layers, verbose=False):
 
         # Get potential dilation rates
         try:
-            dilation = np.array(layer.dilation_rate).astype(np.int)
+            dilation = np.array(layer.dilation_rate).astype(np.int32)
         except AttributeError:
-            dilation = np.ones(shape=[dim], dtype=np.int)
+            dilation = np.ones(shape=[dim], dtype=np.int32)
         if hasattr(layer, "dilations"):
             assert (dilation == 1).all()
             dilation = np.array(layer.dilations)

--- a/utime/utils/system.py
+++ b/utime/utils/system.py
@@ -34,7 +34,7 @@ def get_free_gpus(max_allowed_mem_usage=400):
     try:
         # Get list of GPUs
         gpu_list = check_output(["nvidia-smi", "-L"], universal_newlines=True)
-        gpu_ids = np.array(re.findall(r"GPU[ ]+(\d+)", gpu_list), dtype=np.int)
+        gpu_ids = np.array(re.findall(r"GPU[ ]+(\d+)", gpu_list), dtype=np.int32)
 
         # Query memory usage stats from nvidia-smi
         output = check_output(["nvidia-smi", "-q", "-d", "MEMORY"], universal_newlines=True)


### PR DESCRIPTION
`np.int` was deprecated in NumPy version 1.20. In order to keep U-Time up to date, all instances of `np.int` were replaced with `np.int32`